### PR TITLE
Correct spelling of gatsby-plugin keyword so package shows up in new package library

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "inversify",
     "protoculture",
     "gatsby",
-    "gastsby-plugin"
+    "gatsby-plugin"
   ],
   "bugs": {
     "url": "https://github.com/atrauzzi/gatsby-plugin-protoculture/issues"


### PR DESCRIPTION
https://www.gatsbyjs.org/packages/

You'll need to republish the package to NPM to update our search index.

Thanks!